### PR TITLE
make steempy require steem_dshot instead of steem

### DIFF
--- a/steem/cli.py
+++ b/steem/cli.py
@@ -80,7 +80,7 @@ def legacy():
         '--version',
         action='version',
         version='%(prog)s {version}'.format(
-            version=pkg_resources.require("steem")[0].version
+            version=pkg_resources.require("steem_dshot")[0].version
         )
     )
 


### PR DESCRIPTION
pip installs `steem_dshot`, but `steempy` looks for `steem`:
```
root@624768e9ad0f:/# steempy
Traceback (most recent call last):
  File "/usr/local/bin/steempy", line 7, in <module>
    steem.cli.legacy()
  File "/usr/local/lib/python3.6/site-packages/steem/cli.py", line 83, in legacy
    version=pkg_resources.require("steem")[0].version
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 984, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 870, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'steem' distribution was not found and is required by the application
```